### PR TITLE
modifications/modal

### DIFF
--- a/src/sass/components/_modal.scss
+++ b/src/sass/components/_modal.scss
@@ -43,8 +43,9 @@
   background-color: rgba(94, 99, 99, 0.7);
   opacity: 1;
 
-  
-  transition: opacity $transition-duration $timing-function, visibility $transition-duration $timing-function;
+  transition-property: opacity, visibility;
+  transition-duration: $transition-duration;
+  transition-timing-function: $timing-function;
 }
 
 // Модалка
@@ -65,6 +66,7 @@
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.06);
 
     transform: translateX(-50%) scale(1);
+    
     transition: transform $transition-duration $timing-function;
 
     @media screen and (min-width: $tablet) {
@@ -107,10 +109,6 @@
     &:hover, &:focus {
       fill: getColor('btn-border-accent-color');
     }
-
-    &:focus {
-      outline: 1px solid getColor('btn-border-accent-color');;
-    }
   }
 
   .modal__title {
@@ -150,13 +148,13 @@
     height: 48px;
 
     border-radius: 30px;
-    border: 2px solid getColor('border-input-color');
+    border: 2px solid getColor('border-modal-iput-color');
 
     box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.15);
 
-    outline: none;
-
     transition: border-color $transition-duration $timing-function;
+
+    outline: none;
     
     // Placeholder
     &::placeholder {
@@ -170,9 +168,9 @@
       border-color: getColor('border-error-color');
       }
 
-    // Ховеры, фокусы
-    &:hover, &:focus {
-      outline: 1px solid getColor('btn-border-accent-color');
+    // Валідність + Ховер і Фокус
+    &:valid, &:hover, &:focus {
+      border-color: getColor('border-color');
     }
   }
 
@@ -232,9 +230,7 @@
     
     cursor: pointer;
 
-    transition-property: background-color;
-    transition-duration: $transition-duration;
-    transition-timing-function: $timing-function;
+    transition: background-color $transition-duration $timing-function;
 
     &:hover, &:focus {
       background-color: getColor('link-accent-color');


### PR DESCRIPTION
1. Группирует свойства transition (исключительно для удобства).
2. Возвращает стандартный outline кнопке закрытия.
3. Делает изначальный цвет бордеров на инпутах серым, как на макете.
4. Делает так, что цвет бордеров на инпутах становится зелёными и при ховере с фокусом, и при валидности (на макете при валидности бордеры зелёные).

При этом, инпуты лишаются своего стандартного outline (У меня в ДЗ так было, рекомендация ментора) + вроде, красивее.